### PR TITLE
Move vue to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ npm i vue-demi
 yarn add vue-demi
 ```
 
+Add `vue` and `@vue/composition-api` to your plugin's peer dependencies to specify what versions you supports.
+
 ```json
 {
   "dependencies": {
     "vue-demi": "latest"
+  },
+  "peerDependencies": {
+    "vue": "^2.0.0 || >=3.0.0-rc.0",
+    "@vue/composition-api": "^1.0.0-beta.11"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Add `vue` and `@vue/composition-api` to your plugin's peer dependencies to speci
     "vue-demi": "latest"
   },
   "peerDependencies": {
-    "vue": "^2.0.0 || >=3.0.0-rc.0",
-    "@vue/composition-api": "^1.0.0-beta.11"
+    "@vue/composition-api": "^1.0.0-beta.1",
+    "vue": "^2.0.0 || >=3.0.0-rc.0"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm i vue-demi
 yarn add vue-demi
 ```
 
-Add `vue` and `@vue/composition-api` to your plugin's peer dependencies to specify what versions you supports.
+Add `vue` and `@vue/composition-api` to your plugin's peer dependencies to specify what versions you support.
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,8 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "peerDependencies": {
-    "@vue/composition-api": ">=1.0.0-beta.1"
-  },
-  "devDependencies": {
-    "vue": "^2.6.11"
+    "@vue/composition-api": ">=1.0.0-beta.1",
+    "vue": "^2.0.0 || >=3.0.0-rc.1"
   },
   "files": [
     "lib",


### PR DESCRIPTION
This fixes warning when running app built with `rollup` and build error when build with `webpack` for `yarn@2` users.

Additionally updated README.md to include note for plugin developers to include `vue` and `@vue/composition-api` in their peer dependencies to make them compatible with `yarn@2` too.