### PR TITLE
fix: cjs plugin install

### DIFF
--- a/lib/v2/index.cjs.js
+++ b/lib/v2/index.cjs.js
@@ -2,7 +2,7 @@ const Vue = require('vue')
 const VueCompositionAPI = require('@vue/composition-api')
 
 if (Vue && !Vue['__composition_api_installed__'])
-  Vue.use(VueCompositionAPI)
+  Vue.use(VueCompositionAPI.default)
 
 Object.keys(VueCompositionAPI).forEach(key => {
   exports[key] = VueCompositionAPI[key]


### PR DESCRIPTION
`VueCompositionAPI.default` contains the object with the `install` function.