### PR TITLE
fix(lib/v2): export es6 syntax free es modules

### DIFF
--- a/lib/v2/index.cjs.js
+++ b/lib/v2/index.cjs.js
@@ -1,5 +1,5 @@
-const Vue = require('vue')
-const VueCompositionAPI = require('@vue/composition-api')
+var Vue = require('vue')
+var VueCompositionAPI = require('@vue/composition-api')
 
 if (Vue && !Vue['__composition_api_installed__']) {
   if (VueCompositionAPI && 'default' in VueCompositionAPI)

--- a/lib/v2/index.esm.js
+++ b/lib/v2/index.esm.js
@@ -4,9 +4,9 @@ import VueCompositionAPI from '@vue/composition-api'
 if (Vue && !Vue['__composition_api_installed__'])
   Vue.use(VueCompositionAPI)
 
-const isVue2 = true
-const isVue3 = false
-const version = Vue.version
+var isVue2 = true
+var isVue3 = false
+var version = Vue.version
 
 export * from '@vue/composition-api'
 export {

--- a/lib/v3/index.cjs.js
+++ b/lib/v3/index.cjs.js
@@ -1,4 +1,4 @@
-const Vue = require('vue')
+var Vue = require('vue')
 
 Object.keys(Vue).forEach(key => {
   exports[key] = Vue[key]

--- a/lib/v3/index.esm.js
+++ b/lib/v3/index.esm.js
@@ -1,7 +1,7 @@
 import * as Vue from 'vue'
 
-const isVue2 = false
-const isVue3 = true
+var isVue2 = false
+var isVue3 = true
 
 export * from 'vue'
 export {


### PR DESCRIPTION
remove `const` keyword from preventing compatibility issues