### PR TITLE
chore: Remove arrow function declaration

### DIFF
--- a/lib/v2/index.cjs.js
+++ b/lib/v2/index.cjs.js
@@ -8,7 +8,7 @@ if (Vue && !Vue['__composition_api_installed__']) {
     Vue.use(VueCompositionAPI)
 }
 
-Object.keys(VueCompositionAPI).forEach((key) => {
+Object.keys(VueCompositionAPI).forEach(function(key) {
   exports[key] = VueCompositionAPI[key]
 })
 

--- a/lib/v3/index.cjs.js
+++ b/lib/v3/index.cjs.js
@@ -1,6 +1,6 @@
 var Vue = require('vue')
 
-Object.keys(Vue).forEach(key => {
+Object.keys(Vue).forEach(function(key) {
   exports[key] = Vue[key]
 })
 exports.Vue = Vue


### PR DESCRIPTION
Hi, Antony.
Yesterday's fix in #16  missed modification of arrow function in .cjs format lib outputs.
In case for low browser version compatibility, we also need to remove the definition of arrow functions.