### PR TITLE
feat: add warn function

### DIFF
--- a/lib/index.iife.js
+++ b/lib/index.iife.js
@@ -15,6 +15,7 @@
         VueDemi.isVue3 = false
         VueDemi.Vue = Vue
         VueDemi.version = Vue.version
+        VueDemi.warn = console.warn
       } else {
         console.error(
           '[vue-demi] no VueCompositionAPI instance found, please be sure to import `@vue/composition-api` before `vue-demi`.'

--- a/lib/v2/index.cjs.js
+++ b/lib/v2/index.cjs.js
@@ -15,4 +15,5 @@ Object.keys(VueCompositionAPI).forEach(function(key) {
 exports.Vue = Vue
 exports.isVue2 = true
 exports.isVue3 = false
+exports.warn = console.warn
 exports.version = Vue.version

--- a/lib/v2/index.d.ts
+++ b/lib/v2/index.d.ts
@@ -2,10 +2,12 @@ import Vue from 'vue'
 declare const isVue2: boolean
 declare const isVue3: boolean
 declare const version: string
+declare const warn: typeof console.warn
 export * from '@vue/composition-api'
 export {
   Vue,
   isVue2,
   isVue3,
   version,
+  warn
 }

--- a/lib/v2/index.esm.js
+++ b/lib/v2/index.esm.js
@@ -7,6 +7,7 @@ if (Vue && !Vue['__composition_api_installed__'])
 var isVue2 = true
 var isVue3 = false
 var version = Vue.version
+var warn = console.warn
 
 export * from '@vue/composition-api'
 export {
@@ -14,4 +15,5 @@ export {
   isVue2,
   isVue3,
   version,
+  warn
 }


### PR DESCRIPTION
the `warn` function in Vue 3 adds a stacktrace so I think it's worth for library authors to be able to use it. However, it doesn't exist in Vue 2 (there is `Vue.util.warn`, but it doesn't have a stacktrace)

Because of this I thought of adding `warn` to vue-demi, but maybe a better place would be the composition-api directly 🤔  @pikax

![Screen Shot 2020-11-21 at 12 55 34](https://user-images.githubusercontent.com/664177/99877068-d4afaa80-2bfb-11eb-9a48-16ecab52b506.png)
