### PR TITLE
export warn for Vue 2

### DIFF
--- a/lib/index.iife.js
+++ b/lib/index.iife.js
@@ -14,6 +14,7 @@
         VueDemi.isVue2 = true
         VueDemi.isVue3 = false
         VueDemi.Vue = Vue
+        VueDemi.warn = Vue.util.warn
         VueDemi.version = Vue.version
       } else {
         console.error(

--- a/lib/v2/index.cjs.js
+++ b/lib/v2/index.cjs.js
@@ -15,4 +15,5 @@ Object.keys(VueCompositionAPI).forEach(function(key) {
 exports.Vue = Vue
 exports.isVue2 = true
 exports.isVue3 = false
+exports.warn = Vue.util.warn
 exports.version = Vue.version

--- a/lib/v2/index.d.ts
+++ b/lib/v2/index.d.ts
@@ -1,11 +1,13 @@
 import Vue from 'vue'
 declare const isVue2: boolean
 declare const isVue3: boolean
+declare function warn(msg: string): void
 declare const version: string
 export * from '@vue/composition-api'
 export {
   Vue,
   isVue2,
   isVue3,
+  warn,
   version,
 }

--- a/lib/v2/index.esm.js
+++ b/lib/v2/index.esm.js
@@ -6,6 +6,7 @@ if (Vue && !Vue['__composition_api_installed__'])
 
 var isVue2 = true
 var isVue3 = false
+var warn = Vue.util.warn
 var version = Vue.version
 
 export * from '@vue/composition-api'
@@ -13,5 +14,6 @@ export {
   Vue,
   isVue2,
   isVue3,
+  warn,
   version,
 }


### PR DESCRIPTION
Vue 3 exports the `warn` function. VueDemi should also export the `warn` function.

Fixes https://github.com/posva/vue-promised/issues/233